### PR TITLE
added .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.DS_Store
+.git
+.github
+.gitignore
+.gitlab-ci.yml
+CODEOWNERS
+Jenkinsfile
+LICENSE
+README.md
+
+# Any project-specific files or directories not necessary to run or build the application


### PR DESCRIPTION
**What this PR does / why we need it**:

.dockerignore files are a Docker suggested best practice and help reduce image size.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #16 