### PR TITLE
Versiondoc

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,6 +52,7 @@ publish-master:
   script:
   - docker pull $IMAGE_PROD_NAME
   - docker login ${registry} -u ${quay_org}+${robot_account} -p ${QUAY_PASSWORD}
+  # Any merge to master (i.e. a successful CI pass) will be tagged and pushed as latest
   - docker tag ${IMAGE_PROD_NAME} ${registry}/${quay_org}/${image_name}:latest
   - docker push ${registry}/${quay_org}/${image_name}:latest
 
@@ -62,5 +63,6 @@ publish-version-tag:
   script:
   - docker pull $IMAGE_PROD_NAME
   - docker login ${registry} -u ${quay_org}+${robot_account} -p ${QUAY_PASSWORD}
+  # A tag push to master will be pushed to Quay with that tag
   - docker tag ${IMAGE_PROD_NAME} ${registry}/${quay_org}/${image_name}:$CI_COMMIT_TAG
   - docker push ${registry}/${quay_org}/${image_name}:$CI_COMMIT_TAG

--- a/README.md
+++ b/README.md
@@ -44,3 +44,19 @@ notifications.
 - [Fork](https://help.github.com/articles/fork-a-repo/) the `container-zabra` repo
 (https://github.com/samsung-cnct/container-zabra) from `samsung-cnct` and begin
 submitting PRs.
+
+# Versioning and Release Process
+
+Container images are hosted on [Quay](https://quay.io) under "Repositories". We have the following conventions for versioning:
+
+## Latest
+
+Any image tagged `:latest` is the most recent development version of the image that has passed CI tests. It may change as further adjustments get made. Use at your own risk.
+
+## Tagged versions
+
+Container images are tagged according to the format `<image_name>vx.x.x`
+
+## Releases
+
+Releases are currently done manually, by pushing a tag to a certain state of master. A release will be cut when it is determined to be useful. Each new solas-container repository will be automatically tagged with `v0.0.0`.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Container images are hosted on [Quay](https://quay.io) under "Repositories". We 
 
 ## Latest
 
-Any image tagged `:latest` is the most recent development version of the image that has passed CI tests. It may change as further adjustments get made. Use at your own risk.
+Any image tagged `:latest` is the most recent development version that has passed CI tests. It may change as further adjustments get made. Use at your own risk.
 
 ## Tagged versions
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Any image tagged `:latest` is the most recent development version that has passe
 
 ## Tagged versions
 
-Container images are tagged according to the format `<image_name>vx.x.x`
+Container images are tagged according to the format `<image_name>vx.x.x`. A release version tag is considered to be a fully developed version of the container image.
 
 ## Releases
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the description for the release process and versioning scheme for container repositories.
Code comments indicate where/how this happens.